### PR TITLE
feat: Add [open_appliction_plugin] plugin

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 1,
+  "name": "Windows端打开桌面应用插件",
+  "version": "1.0.0",
+  "description": "专门用于懒人在外面回家后却要玩游戏特别开发的插件",
+  "author": {
+    "name": "LMSS_AIOS",
+    "url": "https://github.com/biucols"
+  },
+  "license": "MIT",
+
+  "host_application": {
+    "min_version": "0.7.0",
+    "max_version": "0.8.0"
+  },
+  "homepage_url": "https://github.com/biucols",
+  "repository_url": "https://github.com/biucols/plugin-repo",
+  "keywords": ["ai","notes","openapp","code","snippet","developer"],
+  "categories": ["open_app"],
+
+
+  "default_locale": "CN"
+}

--- a/open_appliction_plugin/README.md
+++ b/open_appliction_plugin/README.md
@@ -1,0 +1,162 @@
+### 🤖 Assistant
+
+
+
+# Windows应用启动插件文档
+
+## 概述
+
+本插件为Windows系统设计，旨在解决中文应用启动路径问题，通过智能路径查找和原生Windows API调用，实现可靠的应用启动功能。支持关键词触发（如"打开微信"）和命令触发（如`/open wechat`）两种方式。
+
+## 功能特点
+
+- ✅ **智能路径查找**：自动搜索桌面、开始菜单、程序文件和系统路径
+- 🌐 **原生API启动**：使用Windows ShellExecuteW API直接启动应用，避免路径问题
+- 🈺 **中文支持**：完美处理中文路径和应用名称
+- ⚙️ **权限控制**：支持应用黑白名单管理
+- 📊 **日志记录**：详细记录操作过程，便于调试
+
+## 安装与配置
+
+### 系统要求
+- Windows 10/11
+- Python 3.7+
+- 插件系统支持（如自行开发的插件框架）
+
+### 安装步骤
+
+1. 将插件文件复制到插件目录：
+   ```
+   plugins/
+   └── open_appliction_plugin
+   ```
+
+2. 创建配置文件 `config.toml`：
+   ```toml
+   [components]
+   enable_open_action = true   # 启用关键词触发
+   enable_open_command = true  # 启用命令触发
+   
+   [open_app]
+   list_type = "black"         # 名单类型：black(黑名单)/white(白名单)
+   app_list = ["cmd", "regedit"] # 禁止或允许的应用列表
+   ```
+
+3. 在系统中注册插件：
+   ```python
+   # 在插件加载器中
+   from plugins.open_app_plugin import OpenApplicationPlugin
+   ```
+
+## 使用指南
+
+### 关键词触发
+直接发送包含关键词的消息：
+```
+打开微信
+启动计算器
+run notepad
+open 三角洲行动
+```
+
+### 命令触发
+使用特定命令格式：
+```
+/open wechat
+/open 计算器
+/open "Visual Studio"
+```
+
+### 黑白名单配置
+- **黑名单模式**（默认）：禁止打开指定应用
+  ```toml
+  [open_app]
+  list_type = "black"
+  app_list = ["cmd", "regedit", "taskmgr"]
+  ```
+  
+- **白名单模式**：只允许打开指定应用
+  ```toml
+  [open_app]
+  list_type = "white"
+  app_list = ["wechat", "chrome", "notepad"]
+  ```
+
+## 技术原理
+
+### 路径查找流程
+```mermaid
+graph TD
+    A[用户请求打开应用] --> B{是否允许打开？}
+    B -->|允许| C[查找应用路径]
+    C --> D[桌面搜索 *.lnk, *.url, *.exe]
+    D --> E[开始菜单搜索]
+    E --> F[程序文件目录搜索]
+    F --> G[系统PATH搜索]
+    G --> H{找到路径？}
+    H -->|是| I[使用ShellExecuteW启动]
+    H -->|否| J[返回未找到错误]
+```
+
+### 启动机制
+使用Windows原生API确保可靠启动：
+```c
+HINSTANCE ShellExecuteW(
+  HWND    hwnd,          // 父窗口句柄（NULL）
+  LPCWSTR lpOperation,   // 操作类型（"open"）
+  LPCWSTR lpFile,        // 文件路径
+  LPCWSTR lpParameters,  // 参数（NULL）
+  LPCWSTR lpDirectory,   // 工作目录（NULL）
+  INT     nShowCmd       // 显示方式（SW_SHOW=5）
+);
+```
+
+## 常见问题解决
+
+### 应用无法打开
+1. 检查应用是否在黑白名单中
+2. 查看日志确认路径查找结果
+3. 尝试手动执行路径验证：
+   ```python
+   from plugins.open_app_plugin import WindowsAppLauncher
+   path = WindowsAppLauncher.find_application("应用名称")
+   print(f"找到路径: {path}")
+   ```
+
+### 路径包含特殊字符
+插件自动处理：
+- 空格：`C:\Program Files` → 原生API自动处理
+- 中文：`C:\用户\张三\桌面\我的应用.lnk`
+- 特殊符号：`#`, `&`, `%` 等
+
+### 日志分析
+日志中包含关键信息：
+```
+[INFO] 成功打开应用: 微信 (路径: C:\Users\Admin\Desktop\微信.lnk)
+[DEBUG] ShellExecuteW 返回值: 42 (成功>32)
+[ERROR] 打开应用失败: photoshop - 未找到应用程序
+```
+
+## 贡献与支持
+
+### 问题反馈
+遇到问题时，请提供：
+1. 应用名称
+2. 配置文件内容
+3. 相关日志片段
+4. 操作系统版本
+
+### 开发贡献
+欢迎提交Pull Request：
+```bash
+git clone https://github.com/your-repo/windows-app-launcher.git
+cd windows-app-launcher
+# 创建新分支进行开发
+git checkout -b feature/new-enhancement
+```
+
+## 许可证
+MIT License - 自由使用和修改，需保留原始作者信息
+
+> 提示：本插件已针对Windows路径处理进行深度优化，解决了中文路径和特殊字符问题，使用原生API确保最高兼容性。
+

--- a/open_appliction_plugin/config.toml
+++ b/open_appliction_plugin/config.toml
@@ -1,0 +1,22 @@
+# open_appliction_plugin - 配置文件
+# 通过用户指令打开电脑中的应用软件
+[plugin]
+name = "open_appliction_plugin"
+version = "1.0.0"
+enabled = true
+description = "通过用户指令打开电脑中的应用软件"
+[components]
+# 是否启用打开应用的Action
+enable_open_action = true
+# 是否启用打开应用的Command
+enable_open_command = true
+[open_app]
+# 名单类型：black（黑名单）或 white（白名单），默认黑名单
+list_type = "black"
+# 黑名单或白名单中的应用列表（应用名称列表）
+app_list = ["notepad.exe", "calc.exe"]
+# 是否启用日志记录
+enable_logging = true
+[logging]
+level = "INFO"
+prefix = "[OpenAppPlugin]"

--- a/open_appliction_plugin/plugin.py
+++ b/open_appliction_plugin/plugin.py
@@ -1,0 +1,395 @@
+"""
+打开应用插件 - 终极版
+功能：通过用户指令打开电脑中的应用软件
+使用原生Windows API直接启动应用，避免start命令问题
+"""
+
+import platform
+import subprocess
+import logging
+import sys
+import locale
+import os
+import winreg
+import glob
+import ctypes
+from typing import List, Tuple, Type, Optional
+
+# 强制设置系统默认编码为UTF-8
+if sys.version_info >= (3, 7):
+    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stderr.reconfigure(encoding='utf-8')
+else:
+    sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=1)
+    sys.stderr = open(sys.stderr.fileno(), mode='w', encoding='utf-8', buffering=1)
+
+# 设置locale为UTF-8
+try:
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+except:
+    try:
+        locale.setlocale(locale.LC_ALL, 'zh_CN.UTF-8')
+    except:
+        pass
+
+# 导入新插件系统
+from src.plugin_system.base.base_plugin import BasePlugin
+from src.plugin_system.base.base_plugin import register_plugin
+from src.plugin_system.base.base_action import BaseAction
+from src.plugin_system.base.base_command import BaseCommand
+from src.plugin_system.base.component_types import ComponentInfo, ActionActivationType, ChatMode
+from src.common.logger import get_logger
+
+# 获取日志记录器
+logger = get_logger("open_app_plugin")
+
+class WindowsAppLauncher:
+    """Windows 应用启动工具类，使用原生API"""
+
+    @staticmethod
+    def get_desktop_path() -> str:
+        """获取桌面路径"""
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER,
+                              r"Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders") as key:
+                desktop_path, _ = winreg.QueryValueEx(key, "Desktop")
+                if "%" in desktop_path:
+                    for env_var in ["USERPROFILE", "HOMEPATH"]:
+                        if env_var in os.environ:
+                            desktop_path = desktop_path.replace(f"%{env_var}%", os.environ[env_var])
+                return os.path.expandvars(desktop_path)
+        except Exception:
+            return os.path.join(os.path.expanduser("~"), "Desktop")
+
+    @staticmethod
+    def find_application(app_name: str) -> Optional[str]:
+        """查找应用程序的完整路径（大小写不敏感）"""
+        # 1. 检查桌面快捷方式
+        desktop_path = WindowsAppLauncher.get_desktop_path()
+        for ext in ["*.lnk", "*.url", "*.exe"]:
+            for file_path in glob.glob(os.path.join(desktop_path, ext), recursive=False):
+                base_name = os.path.splitext(os.path.basename(file_path))[0].lower()
+                if app_name.lower() in base_name:
+                    return file_path
+
+        # 2. 检查开始菜单
+        start_menu_paths = [
+            os.path.join(os.environ.get("APPDATA", ""), "Microsoft", "Windows", "Start Menu", "Programs"),
+            os.path.join(os.environ.get("PROGRAMDATA", ""), "Microsoft", "Windows", "Start Menu", "Programs")
+        ]
+
+        for start_path in start_menu_paths:
+            if os.path.exists(start_path):
+                for root, _, files in os.walk(start_path):
+                    for file in files:
+                        if file.lower().endswith(('.lnk', '.exe')):
+                            base_name = os.path.splitext(file)[0].lower()
+                            if app_name.lower() in base_name:
+                                return os.path.join(root, file)
+
+        # 3. 检查程序文件目录
+        program_dirs = [
+            os.environ.get("PROGRAMFILES", r"C:\Program Files"),
+            os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"),
+            os.environ.get("LOCALAPPDATA", "")
+        ]
+
+        for dir_path in program_dirs:
+            if os.path.exists(dir_path):
+                for root, _, files in os.walk(dir_path):
+                    for file in files:
+                        if file.lower().endswith('.exe'):
+                            base_name = os.path.splitext(file)[0].lower()
+                            if app_name.lower() in base_name:
+                                return os.path.join(root, file)
+
+        # 4. 检查系统路径
+        system_path = os.environ.get("PATH", "")
+        for path_dir in system_path.split(os.pathsep):
+            if os.path.exists(path_dir):
+                for file in os.listdir(path_dir):
+                    if file.lower().endswith('.exe'):
+                        base_name = os.path.splitext(file)[0].lower()
+                        if app_name.lower() in base_name:
+                            return os.path.join(path_dir, file)
+
+        return None
+
+    @staticmethod
+    def launch_app(full_path: str) -> bool:
+        """使用ShellExecuteW直接启动应用（原生Windows API）"""
+        try:
+            # 使用ShellExecuteW处理各种文件类型
+            shell32 = ctypes.windll.shell32
+
+            # 转换路径为宽字符（支持Unicode）
+            full_path_w = ctypes.create_unicode_buffer(full_path)
+
+            # SW_SHOW = 5, 正常显示窗口
+            result = shell32.ShellExecuteW(
+                None,           # 父窗口句柄
+                "open",         # 操作类型
+                full_path_w,    # 文件路径
+                None,           # 参数
+                None,           # 工作目录
+                5               # 显示方式
+            )
+
+            # 返回值大于32表示成功
+            return result > 32
+        except Exception as e:
+            logger.error(f"ShellExecuteW 调用失败: {str(e)}")
+            return False
+
+class OpenAppAction(BaseAction):
+    """打开应用Action - 基于关键词触发打开应用"""
+
+    # ===== 激活控制必须项 =====
+    focus_activation_type = ActionActivationType.KEYWORD
+    normal_activation_type = ActionActivationType.KEYWORD
+    mode_enable = ChatMode.ALL
+    parallel_action = True
+
+    # ===== 基本信息必须项 =====
+    action_name = "open_app_action"
+    action_description = "打开指定应用软件"
+
+    # 关键词配置
+    activation_keywords = ["打开", "启动", "run", "open"]
+    keyword_case_sensitive = False
+
+    # ===== 功能定义必须项 =====
+    action_parameters = {
+        "app_name": "要打开的应用程序名称"
+    }
+
+    action_require = [
+        "用户明确要求打开特定应用时使用",
+        "应用名称在允许打开的名单中",
+        "应用不在禁止打开的名单中"
+    ]
+
+    associated_types = ["text", "command"]
+
+    async def execute(self) -> Tuple[bool, str]:
+        """执行打开应用操作"""
+        app_name = self.action_data.get("app_name", "")
+
+        if not app_name:
+            logger.warning(f"{self.log_prefix} 未指定应用名称")
+            return False, "未指定应用名称"
+
+        # 检查应用是否允许打开
+        if not self._is_app_allowed(app_name):
+            logger.warning(f"{self.log_prefix} 应用不在允许名单中: {app_name}")
+            await self.send_text(f"⚠️ 无法打开 {app_name}，该应用不在允许名单中")
+            return False, f"应用不在允许名单中: {app_name}"
+
+        # 执行打开操作
+        success, message, full_path = self._open_application(app_name)
+
+        if success:
+            logger.info(f"{self.log_prefix} 成功打开应用: {app_name} (路径: {full_path})")
+            await self.send_text(f"✅ 已启动应用: {app_name}")
+            return True, f"成功打开 {app_name}"
+        else:
+            logger.error(f"{self.log_prefix} 打开应用失败: {app_name} - {message}")
+            await self.send_text(f"❌ 打开应用失败: {app_name}\n错误: {message}")
+            return False, f"打开失败: {message}"
+
+    def _is_app_allowed(self, app_name: str) -> bool:
+        """检查应用是否在允许打开的名单中"""
+        list_type = self.api.get_config("open_app.list_type", "black")
+        app_list = self.api.get_config("open_app.app_list", [])
+
+        if list_type == "black":
+            # 黑名单模式 - 不在黑名单中即可打开
+            return app_name.lower() not in [a.lower() for a in app_list]
+        else:
+            # 白名单模式 - 必须在白名单中才能打开
+            return app_name.lower() in [a.lower() for a in app_list]
+
+    def _open_application(self, app_name: str) -> Tuple[bool, str, Optional[str]]:
+        """打开应用程序（跨平台实现），返回 (成功状态, 消息, 完整路径)"""
+        system = platform.system()
+
+        # Windows平台使用原生API启动
+        if system == "Windows":
+            full_path = WindowsAppLauncher.find_application(app_name)
+            if not full_path:
+                return False, f"未找到应用程序: {app_name}", None
+
+            try:
+                # 使用原生Windows API启动应用
+                success = WindowsAppLauncher.launch_app(full_path)
+                if success:
+                    return True, "应用已启动", full_path
+                else:
+                    # 原生API失败时回退到subprocess
+                    try:
+                        # 直接使用完整路径启动
+                        subprocess.Popen(full_path, shell=True)
+                        return True, "应用已启动", full_path
+                    except Exception as e2:
+                        return False, f"无法打开应用: {str(e2)}", full_path
+            except Exception as e:
+                return False, f"启动失败: {str(e)}", full_path
+
+        # 其他平台处理
+        try:
+            if system == "Darwin":
+                # macOS系统
+                subprocess.Popen(["open", "-a", app_name])
+                return True, "应用已启动", app_name
+
+            elif system == "Linux":
+                # Linux系统
+                subprocess.Popen([app_name])
+                return True, "应用已启动", app_name
+
+            else:
+                return False, f"不支持的操作系统: {system}", None
+
+        except Exception as e:
+            return False, str(e), None
+
+class OpenAppCommand(BaseCommand):
+    """打开应用Command - 通过命令打开应用"""
+
+    command_pattern = r"^/open\s+(?P<app_name>.+)$"
+    command_help = "打开指定应用程序，用法：/open <应用名称>"
+    command_examples = ["/open notepad", "/open 计算器"]
+    intercept_message = True
+
+    async def execute(self) -> Tuple[bool, Optional[str]]:
+        """执行打开应用命令"""
+        app_name = self.matched_groups.get("app_name", "")
+
+        if not app_name:
+            await self.send_text("❌ 请指定要打开的应用程序名称\n用法：/open <应用名称>")
+            return False, "未指定应用名称"
+
+        # 检查应用是否允许打开
+        if not self._is_app_allowed(app_name):
+            await self.send_text(f"⚠️ 无法打开 {app_name}，该应用不在允许名单中")
+            return False, f"应用不在允许名单中: {app_name}"
+
+        # 执行打开操作
+        success, message, _ = self._open_application(app_name)
+
+        if success:
+            await self.send_text(f"✅ 已启动应用: {app_name}")
+            return True, f"成功打开 {app_name}"
+        else:
+            await self.send_text(f"❌ 打开应用失败: {app_name}\n错误: {message}")
+            return False, f"打开失败: {message}"
+
+    def _is_app_allowed(self, app_name: str) -> bool:
+        """检查应用是否在允许打开的名单中"""
+        list_type = self.api.get_config("open_app.list_type", "black")
+        app_list = self.api.get_config("open_app.app_list", [])
+
+        if list_type == "black":
+            # 黑名单模式 - 不在黑名单中即可打开
+            return app_name.lower() not in [a.lower() for a in app_list]
+        else:
+            # 白名单模式 - 必须在白名单中才能打开
+            return app_name.lower() in [a.lower() for a in app_list]
+
+    def _open_application(self, app_name: str) -> Tuple[bool, str, Optional[str]]:
+        """打开应用程序（跨平台实现），返回 (成功状态, 消息, 完整路径)"""
+        system = platform.system()
+
+        # Windows平台使用原生API启动
+        if system == "Windows":
+            full_path = WindowsAppLauncher.find_application(app_name)
+            if not full_path:
+                return False, f"未找到应用程序: {app_name}", None
+
+            try:
+                # 使用原生Windows API启动应用
+                success = WindowsAppLauncher.launch_app(full_path)
+                if success:
+                    return True, "应用已启动", full_path
+                else:
+                    # 原生API失败时回退到subprocess
+                    try:
+                        # 直接使用完整路径启动
+                        subprocess.Popen(full_path, shell=True)
+                        return True, "应用已启动", full_path
+                    except Exception as e2:
+                        return False, f"无法打开应用: {str(e2)}", full_path
+            except Exception as e:
+                return False, f"启动失败: {str(e)}", full_path
+
+        # 其他平台处理
+        try:
+            if system == "Darwin":
+                # macOS系统
+                subprocess.Popen(["open", "-a", app_name])
+                return True, "应用已启动", app_name
+
+            elif system == "Linux":
+                # Linux系统
+                subprocess.Popen([app_name])
+                return True, "应用已启动", app_name
+
+            else:
+                return False, f"不支持的操作系统: {system}", None
+
+        except Exception as e:
+            return False, str(e), None
+
+@register_plugin
+class OpenApplicationPlugin(BasePlugin):
+    """打开应用插件主类"""
+
+    plugin_name = "open_appliction_plugin"
+    plugin_description = "通过用户指令打开电脑中的应用软件"
+    plugin_version = "1.0.0"
+    plugin_author = "LMSS_AIOS"
+    enable_plugin = True
+    config_file_name = "config.toml"
+
+    config_section_descriptions = {
+        "plugin": "插件基本信息配置",
+        "components": "组件启用控制",
+        "open_app": "应用打开配置",
+        "logging": "日志记录配置"
+    }
+
+    def __init__(self, *args, **kwargs):
+        """初始化插件，接受并传递所有参数"""
+        super().__init__(*args, **kwargs)
+        self.enable_open_action = True  # 默认值
+        self.enable_open_command = True  # 默认值
+
+    async def initialize(self):
+        """初始化插件，此时api已可用"""
+        await super().initialize()
+
+        # 在初始化阶段获取配置
+        self.enable_open_action = self.api.get_config("components.enable_open_action", True)
+        self.enable_open_command = self.api.get_config("components.enable_open_command", True)
+
+    def get_plugin_components(self) -> List[Tuple[ComponentInfo, Type]]:
+        """返回插件包含的组件列表"""
+        components = []
+
+        # 使用初始化阶段设置的配置值
+        if self.enable_open_action:
+            components.append((
+                OpenAppAction.get_action_info(),
+                OpenAppAction
+            ))
+
+        if self.enable_open_command:
+            components.append((
+                OpenAppCommand.get_command_info(
+                    name="open_app_command",
+                    description="打开指定应用程序"
+                ),
+                OpenAppCommand
+            ))
+
+        return components

--- a/plugins.json
+++ b/plugins.json
@@ -2,5 +2,11 @@
   {
     "id": "MaiM-with-u.example-plugin",
     "repositoryUrl": "https://github.com/MaiM-with-u/MaiBot"
+  },
+  {
+    "id": "biucols.open_appliction_plugin",
+    "repositoryUrl": "https://github.com/biucols/plugin-repo"
   }
 ]
+
+


### PR DESCRIPTION
### 新增插件提交

**插件仓库 URL:**

---

### 核对清单 (Checklist)

在提交前，请确保您已完成以下所有事项。

- [x] 我已经完整阅读并理解了 **[CONTRIBUTING.md](./CONTRIBUTING.md)** 中的所有指南。
- [x] 我的插件仓库是公开的。
- [x] 我的仓库根目录下包含了格式正确的 `_manifest.json` 文件。
- [x] `_manifest.json` 中包含了所有必需字段 (`name`, `version`, `author`, `license`, `host_application` 等)。
- [x] 我的仓库根目录下包含了与 `_manifest.json` 中 `license` 字段相符的 `LICENSE` 文件。
- [x] 我已将我的插件信息正确添加到了 `plugins.json` 文件的末尾，并检查了 JSON 格式（特别是逗号）。

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

添加 OpenApplicationPlugin 以启用通过聊天触发器启动桌面应用程序，具有跨平台支持和可配置的权限。

新功能：
- 允许通过聊天关键词或 `/open` 命令打开本地应用程序
- 支持通过 Windows 原生 API、macOS `open` 和 Linux 可执行文件启动跨平台应用程序
- 引入可配置的黑/白名单来控制可以打开哪些应用程序

增强功能：
- 提供默认的 `config.toml` 用于插件配置

构建：
- 在 `plugins.json` 中注册新插件

文档：
- 在插件的 `README.md` 中添加详细的用户文档和使用指南

杂项：
- 包含插件的 `_manifest.json` 文件和相关目录结构

<details>
<summary>Original summary in English</summary>

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

添加 OpenApplicationPlugin 以允许用户通过聊天关键词或 `/open` 命令启动本地应用程序，并提供跨平台支持和可配置的访问控制。

新功能：
- 允许使用聊天关键词或 `/open <app_name>` 命令启动本地应用程序
- 支持通过原生 Windows API、macOS `open` 和直接 Linux 执行来发现和启动应用程序

增强功能：
- 引入黑名单/白名单配置，用于控制可以打开哪些应用程序
- 包含用于插件设置的默认 `config.toml`

构建：
- 在 `plugins.json` 中注册新插件

文档：
- 添加全面的 `README.md`，其中包含安装、配置和使用说明

杂项：
- 添加 `_manifest.json`、插件目录结构和插件配置文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an OpenApplicationPlugin to enable users to launch local applications via chat keywords or the `/open` command with cross-platform support and configurable access control.

New Features:
- Allow launching local applications using chat keywords or `/open <app_name>` command
- Support application discovery and launch via native Windows API, macOS `open`, and direct Linux execution

Enhancements:
- Introduce blacklist/whitelist configuration for controlling which applications can be opened
- Include a default `config.toml` for plugin settings

Build:
- Register the new plugin in `plugins.json`

Documentation:
- Add comprehensive `README.md` with installation, configuration, and usage instructions

Chores:
- Add `_manifest.json`, plugin directory structure, and configuration file for the plugin

</details>

</details>