### PR TITLE
Add/send image plugin sf

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -14,7 +14,7 @@
   {
     "id": "Schxar.MaiBot-DoubaoSearch-Plugin",
     "repositoryUrl": "https://github.com/schxar/doubao_search_plugin"
-  }
+  },
   {
     "id": "minecraft1024a.MaiBot-Send-Image-Plugin-S.F.",
     "repositoryUrl": "https://github.com/minecraft1024a/MaiBot-Send-Image-Plugin-S.F."

--- a/plugins.json
+++ b/plugins.json
@@ -16,7 +16,7 @@
     "repositoryUrl": "https://github.com/schxar/doubao_search_plugin"
   },
   {
-    "id": "minecraft1024a.MaiBot-Send-Image-Plugin-S.F.",
-    "repositoryUrl": "https://github.com/minecraft1024a/MaiBot-Send-Image-Plugin-S.F."
+    "id": "minecraft1024a.MaiBot-Send-Image-Plugin-SF",
+    "repositoryUrl": "https://github.com/minecraft1024a/MaiBot-Send-Image-Plugin-SF"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -15,4 +15,8 @@
     "id": "Schxar.MaiBot-DoubaoSearch-Plugin",
     "repositoryUrl": "https://github.com/schxar/doubao_search_plugin"
   }
+  {
+    "id": "minecraft1024a.MaiBot-Send-Image-Plugin-S.F.",
+    "repositoryUrl": "https://github.com/minecraft1024a/MaiBot-Send-Image-Plugin-S.F."
+  }
 ]


### PR DESCRIPTION
### 新增插件提交

**插件仓库 URL:https://github.com/minecraft1024a/MaiBot-Send-Image-Plugin-SF**

---

### 核对清单 (Checklist)

在提交前，请确保您已完成以下所有事项。

- [ √] 我已经完整阅读并理解了 **[CONTRIBUTING.md](./CONTRIBUTING.md)** 中的所有指南。
- [ √] 我的插件仓库是公开的。
- [√ ] 我的仓库根目录下包含了格式正确的 `_manifest.json` 文件。
- [ √] `_manifest.json` 中包含了所有必需字段 (`name`, `version`, `author`, `license`, `host_application` 等)。
- [ √] 我的仓库根目录下包含了与 `_manifest.json` 中 `license` 字段相符的 `LICENSE` 文件。
- [ √] 我已将我的插件信息正确添加到了 `plugins.json` 文件的末尾，并检查了 JSON 格式（特别是逗号）。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

新功能：
- 在 plugins.json 中添加 MaiBot-Send-Image-Plugin-SF 插件条目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add MaiBot-Send-Image-Plugin-SF plugin entry to plugins.json

</details>