### PR TITLE
feat: Add wentaoxian6-svg. MaiBot-rule_horror_plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -350,5 +350,9 @@
   {
     "id": "ThelevenFD.wait_remover",
     "repositoryUrl": "https://github.com/ThelevenFD/wait_remover"
+  },
+  {
+    "id": "wentaoxian6-svg. MaiBot-rule_horror_plugin",
+    "repositoryUrl": "https://github.com/wentaoxian6-svg/MaiBot-rule_horror_plugin"
   }
 ]


### PR DESCRIPTION
## 新增插件提交

**插件仓库 URL:** https://github.com/wentaoxian6-svg/MaiBot-rule_horror_plugin

---

## 核对清单

- [x] 我已经完整阅读并理解了 CONTRIBUTING.md 中的所有指南。
- [x] 我的插件仓库是公开的。
- [x] 我的仓库根目录下包含了格式正确的 _manifest.json 文件。
- [x] _manifest.json 中包含了所有必需字段。
- [x] 我的仓库根目录下包含了与 _manifest.json 中 license 字段相符的 LICENSE 文件。
- [x] 我已将我的插件信息正确添加到了 plugins. json 文件的末尾，并检查了 JSON 格式。

## 插件信息

- **插件名称**:  规则怪谈插件
- **功能描述**: 生成规则怪谈并进行互动游戏，支持LLM生成、提示、推理和多种结局判定
- **作者**: 岚影鸿夜